### PR TITLE
Support http and socks5 proxy and fix failure due to updates of DOM on Google SERP

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ GET http://127.0.0.1:7000/google/image?text=golden puppy&limit=100
 
 ## CLI <a name="cli"></a> ⌨️
 
-- Use `-h` flag to see commands.
+- Use `-h` flag to see all commands.
 - You can use `serve` command to serve API:
 
 ```bash
@@ -104,6 +104,22 @@ As a result you should get JSON output containting search results:
 ]
 ```
 
+### Proxy Support
+
+Both browser mode and raw mode support HTTP and SOCKS5 proxies with authentication:
+
+```bash
+# HTTP proxy with auth
+openserp search google "query" --proxy http://user:pass@127.0.0.1:8080
+
+# Serve with SOCKS5 proxy
+openserp serve --proxy socks5://127.0.0.1:1080
+
+# For HTTPS sites through HTTP proxy, use --insecure to ignore certificate errors
+openserp search google "query" --proxy http://127.0.0.1:8080 --insecure
+openserp search google "query" -x http://127.0.0.1:8080 -k
+```
+
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
@@ -111,4 +127,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Bugs + Questions 👾
 
 If you have some issues/bugs/questions, feel free to open an issue.
-

--- a/README.md
+++ b/README.md
@@ -1,18 +1,23 @@
 # OpenSERP (Search Engine Results Page)
+
 ![OpenSERP](/logo.png)
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/karust/openserp)](https://goreportcard.com/report/github.com/karust/openserp)
 [![Go Reference](https://pkg.go.dev/badge/github.com/karust/openserp.svg)](https://pkg.go.dev/github.com/karust/openserp)
 [![release](https://img.shields.io/github/release-pre/karust/openserp.svg)](https://github.com/karust/openserp/releases)
+
 <!-- ![Docker Image Size (tag)](https://img.shields.io/docker/image-size/karust/openserp/latest) -->
+
 API access for search engines results if available isn't free.
 
 Using OpenSERP, you can get search results from **Google**, **Yandex**, **Baidu** via API or CLI!
 
 See [Docker](#docker) and [CLI](#cli) usage examples below ([search](#search), [images](#images)).
 
-## Docker usage  <a name="docker"></a> 🐳
-* Run API server:
+## Docker usage <a name="docker"></a> 🐳
+
+- Run API server:
+
 ```bash
 # Use prebuilt image
 docker run -p 127.0.0.1:7000:7000 -it karust/openserp serve -a 0.0.0.0 -p 7000
@@ -22,26 +27,32 @@ docker-compose up --build
 ```
 
 ### Request parameters
-| Param | Description                                                  |
-|-------|--------------------------------------------------------------|
-| text  | Text to search                                               |
-| lang  | Search pages in selected language (`EN`, `DE`, `RU`...)      |
-| date  | Date in `YYYYMMDD..YYYYMMDD` format (e.g. 20181010..20231010) |
-| file  | File extension to search  (e.g. `PDF`, `DOC`)                 |
-| site  | Search within a specific website                                 |
-| limit | Limit the number of results  
-| answers | Include google answers as negative rank indexes (e.g. `true`, `false`)
+
+| Param   | Description                                                            |
+| ------- | ---------------------------------------------------------------------- |
+| text    | Text to search                                                         |
+| lang    | Search pages in selected language (`EN`, `DE`, `RU`...)                |
+| date    | Date in `YYYYMMDD..YYYYMMDD` format (e.g. 20181010..20231010)          |
+| file    | File extension to search (e.g. `PDF`, `DOC`)                           |
+| site    | Search within a specific website                                       |
+| limit   | Limit the number of results                                            |
+| answers | Include google answers as negative rank indexes (e.g. `true`, `false`) |
 
 ### **Search**
-### *Example request*
+
+### _Example request_
+
 Get 20 **Google** results for `hello world`, only in English:
+
 ```
 GET http:/127.0.0.1:7000/google/search?lang=EN&limit=20&text=hello world
 ```
-You can replace `google` to `yandex` or `baidu` in query to change search engine.
-                                |
 
-### *Example response*
+You can replace `google` to `yandex` or `baidu` in query to change search engine.
+|
+
+### _Example response_
+
 ```JSON
 [
     {
@@ -53,39 +64,51 @@ You can replace `google` to `yandex` or `baidu` in query to change search engine
     },
 ]
 ```
+
 ### **Images** **[WIP]**
-### *Example request*
+
+### _Example request_
+
 Get 100 **Google** results for `golden puppy`:
+
 ```
 GET http://127.0.0.1:7000/google/image?text=golden puppy&limit=100
 ```
 
-
 ## CLI <a name="cli"></a> ⌨️
-* Use `-h` flag to see commands.
-* You can use `serve` command to serve API:
+
+- Use `-h` flag to see commands.
+- You can use `serve` command to serve API:
+
 ```bash
-openserp serve 
+openserp serve
 ```
-* Or print results in CLI using `search` command:
+
+- Or print results in CLI using `search` command:
+
 ```bash
 openserp search google "how to get banned from google fast" # Change `google` to `yandex` or `baidu`
 ```
+
 As a result you should get JSON output containting search results:
+
 ```json
 [
- {
-  "rank": 1,
-  "url": "https://www.cyberoptik.net/blog/6-sure-fire-ways-to-get-banned-from-google/",
-  "title": "11 Sure-Fire Ways to Get Banned From Google | CyberOptik",
-  "description": "How To Get Banned From Google · 1. Cloaking: The Art of Deception · 2. Plagiarism: Because Originality is Overrated · 3. Keyword Stuffing: More is Always Better · 4 ...",
-  "ad": false
- },
+  {
+    "rank": 1,
+    "url": "https://www.cyberoptik.net/blog/6-sure-fire-ways-to-get-banned-from-google/",
+    "title": "11 Sure-Fire Ways to Get Banned From Google | CyberOptik",
+    "description": "How To Get Banned From Google · 1. Cloaking: The Art of Deception · 2. Plagiarism: Because Originality is Overrated · 3. Keyword Stuffing: More is Always Better · 4 ...",
+    "ad": false
+  }
 ]
- ```
+```
 
- ## License
+## License
+
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details
 
 ## Bugs + Questions 👾
+
 If you have some issues/bugs/questions, feel free to open an issue.
+

--- a/baidu/search.go
+++ b/baidu/search.go
@@ -138,7 +138,7 @@ func (baid *Baidu) Search(query core.Query) ([]core.SearchResult, error) {
 		}
 	}
 
-	return searchResults, nil
+	return core.DeduplicateResults(searchResults), nil
 }
 
 func (baid *Baidu) SearchImage(query core.Query) ([]core.SearchResult, error) {
@@ -231,5 +231,5 @@ func (baid *Baidu) SearchImage(query core.Query) ([]core.SearchResult, error) {
 		}
 	}
 
-	return searchResults, nil
+	return core.DeduplicateResults(searchResults), nil
 }

--- a/baidu/search_raw.go
+++ b/baidu/search_raw.go
@@ -113,5 +113,5 @@ func Search(query core.Query) ([]core.SearchResult, error) {
 	}
 	logrus.Debugf("Baidu Raw results : %v", results)
 
-	return results, nil
+	return core.DeduplicateResults(results), nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -135,6 +135,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&config.App.IsRawRequests, "raw", "r", false, "Disable browser usage, use HTTP requests")
 	RootCmd.PersistentFlags().BoolVarP(&config.App.IsLeaveHead, "leave", "", false, "Leave browser and tabs opened after search is made")
 	RootCmd.PersistentFlags().StringVarP(&config.Config2Capcha.ApiKey, "2captcha_key", "", "", "2 captcha api key")
-	RootCmd.PersistentFlags().StringVarP(&config.App.ProxyURL, "proxy", "", "", "HTTP proxy URL (e.g. http://user:pass@proxy:8080)")
+	RootCmd.PersistentFlags().StringVarP(&config.App.ProxyURL, "proxy", "x", "", "HTTP or Socks5 proxy URL (e.g. http://user:pass@127.0.0.1:8080)")
 	RootCmd.PersistentFlags().BoolVarP(&config.App.Insecure, "insecure", "k", false, "Allow insecure TLS connections")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,8 @@ type AppConfig struct {
 	IsDebug       bool   `mapstructure:"debug"`
 	IsVerbose     bool   `mapstructure:"verbose"`
 	IsRawRequests bool   `mapstructure:"raw_requests"`
+	ProxyURL      string `mapstructure:"proxy"`
+	Insecure      bool   `mapstructure:"insecure"`
 }
 
 var config = Config{}
@@ -133,4 +135,6 @@ func init() {
 	RootCmd.PersistentFlags().BoolVarP(&config.App.IsRawRequests, "raw", "r", false, "Disable browser usage, use HTTP requests")
 	RootCmd.PersistentFlags().BoolVarP(&config.App.IsLeaveHead, "leave", "", false, "Leave browser and tabs opened after search is made")
 	RootCmd.PersistentFlags().StringVarP(&config.Config2Capcha.ApiKey, "2captcha_key", "", "", "2 captcha api key")
+	RootCmd.PersistentFlags().StringVarP(&config.App.ProxyURL, "proxy", "", "", "HTTP proxy URL (e.g. http://user:pass@proxy:8080)")
+	RootCmd.PersistentFlags().BoolVarP(&config.App.Insecure, "insecure", "k", false, "Allow insecure TLS connections")
 }

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -26,8 +26,10 @@ func search(cmd *cobra.Command, args []string) {
 	var err error
 	engineType := args[0]
 	query := core.Query{
-		Text:  args[1],
-		Limit: 10,
+		Text:     args[1],
+		Limit:    10,
+		ProxyURL: config.App.ProxyURL,
+		Insecure: config.App.Insecure,
 	}
 	results := []core.SearchResult{}
 

--- a/cmd/search.go
+++ b/cmd/search.go
@@ -61,6 +61,8 @@ func searchBrowser(engineType string, query core.Query) ([]core.SearchResult, er
 		Timeout:             time.Second * time.Duration(config.App.Timeout),
 		LeavePageOpen:       config.App.IsLeaveHead,
 		CaptchaSolverApiKey: config.Config2Capcha.ApiKey,
+		ProxyURL:            config.App.ProxyURL,
+		Insecure:            config.App.Insecure,
 	}
 
 	if config.App.IsDebug {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/karust/openserp/baidu"
@@ -9,7 +10,47 @@ import (
 	"github.com/karust/openserp/yandex"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"golang.org/x/time/rate"
 )
+
+// rawEngine implements SearchEngine interface for raw HTTP requests
+type rawEngine struct {
+	name string
+}
+
+func (r *rawEngine) Search(q core.Query) ([]core.SearchResult, error) {
+	// Inject proxy settings from config
+	q.ProxyURL = config.App.ProxyURL
+	q.Insecure = config.App.Insecure
+
+	switch r.name {
+	case "google":
+		return google.Search(q)
+	case "yandex":
+		return yandex.Search(q)
+	case "baidu":
+		return baidu.Search(q)
+	default:
+		return nil, fmt.Errorf("unsupported engine: %s", r.name)
+	}
+}
+
+func (r *rawEngine) SearchImage(q core.Query) ([]core.SearchResult, error) {
+	return nil, fmt.Errorf("image search is not supported in raw mode for %s", r.name)
+}
+
+func (r *rawEngine) Name() string {
+	return r.name
+}
+
+func (r *rawEngine) IsInitialized() bool {
+	return true
+}
+
+func (r *rawEngine) GetRateLimiter() *rate.Limiter {
+	// Use default rate limiter for raw requests
+	return rate.NewLimiter(rate.Every(time.Second), 5)
+}
 
 var serveCMD = &cobra.Command{
 	Use:     "serve",
@@ -20,6 +61,17 @@ var serveCMD = &cobra.Command{
 }
 
 func serve(cmd *cobra.Command, args []string) {
+	if config.App.IsRawRequests {
+		logrus.Warn("Browserless results are very inconsistent or may not even work!")
+		serv := core.NewServer(config.App.Host, config.App.Port,
+			&rawEngine{name: "google"},
+			&rawEngine{name: "yandex"},
+			&rawEngine{name: "baidu"},
+		)
+		serv.Listen()
+		return
+	}
+
 	opts := core.BrowserOpts{
 		IsHeadless:          !config.App.IsBrowserHead, // Disable headless if browser head mode is set
 		IsLeakless:          config.App.IsLeakless,
@@ -37,6 +89,7 @@ func serve(cmd *cobra.Command, args []string) {
 	browser, err := core.NewBrowser(opts)
 	if err != nil {
 		logrus.Error(err)
+		return
 	}
 
 	yand := yandex.New(*browser, config.YandexConfig)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -26,6 +26,8 @@ func serve(cmd *cobra.Command, args []string) {
 		Timeout:             time.Second * time.Duration(config.App.Timeout),
 		LeavePageOpen:       config.App.IsLeaveHead,
 		CaptchaSolverApiKey: config.Config2Capcha.ApiKey,
+		ProxyURL:            config.App.ProxyURL,
+		Insecure:            config.App.Insecure,
 	}
 
 	if config.App.IsDebug {

--- a/core/common.go
+++ b/core/common.go
@@ -20,6 +20,26 @@ type SearchResult struct {
 	Ad          bool   `json:"ad"`
 }
 
+func DeduplicateResults(results []SearchResult) []SearchResult {
+	unique := make(map[string]bool)
+	var deduped []SearchResult
+
+	for _, result := range results {
+		if result.URL == "" {
+			continue
+		}
+		if !unique[result.URL] {
+			unique[result.URL] = true
+			deduped = append(deduped, result)
+		}
+	}
+
+	sort.Slice(deduped, func(i, j int) bool {
+		return deduped[i].Rank < deduped[j].Rank
+	})
+	return deduped
+}
+
 func ConvertSearchResultsMap(searchResultsMap map[string]SearchResult) *[]SearchResult {
 	searchResults := []SearchResult{}
 

--- a/core/common.go
+++ b/core/common.go
@@ -41,6 +41,8 @@ type Query struct {
 	Site         string // Search site
 	Limit        int    // Limit the number of results
 	Answers      bool   // Include question and answers from SERP page to results with negative indexes
+	ProxyURL     string // Proxy URL for raw requests
+	Insecure     bool   // Allow insecure TLS connections
 }
 
 func (q Query) IsEmpty() bool {

--- a/google/search.go
+++ b/google/search.go
@@ -293,7 +293,7 @@ func (gogl *Google) Search(query core.Query) ([]core.SearchResult, error) {
 			// Get description
 			text := resEl.MustText()
 			textSliced := strings.Split(text, "\n")
-			srchRes.Description = strings.Join(textSliced[4:], "\n")
+			srchRes.Description = strings.Join(textSliced[:], "\n")
 
 		} else {
 			//fmt.Println(i, attrs)

--- a/google/search.go
+++ b/google/search.go
@@ -132,6 +132,7 @@ func (gogl *Google) acceptCookies(page *rod.Page) {
 	btnElms[3].Click(proto.InputMouseButtonLeft, 1)
 
 }
+
 func (gogl *Google) Search(query core.Query) ([]core.SearchResult, error) {
 	logrus.Tracef("Start Google search, query: %+v", query)
 
@@ -281,20 +282,8 @@ func (gogl *Google) Search(query core.Query) ([]core.SearchResult, error) {
 				srchRes.URL = href.String()
 			}
 
-			// Skip if URL is empty or we've already seen this URL
+			// Skip if URL is empty
 			if srchRes.URL == "" {
-				continue
-			}
-
-			// Check for duplicates
-			isDuplicate := false
-			for _, existing := range searchResults {
-				if existing.URL == srchRes.URL {
-					isDuplicate = true
-					break
-				}
-			}
-			if isDuplicate {
 				continue
 			}
 
@@ -337,7 +326,7 @@ func (gogl *Google) Search(query core.Query) ([]core.SearchResult, error) {
 		searchResults = append(searchResults, srchRes)
 	}
 
-	return searchResults, nil
+	return core.DeduplicateResults(searchResults), nil
 }
 
 func (gogl *Google) SearchImage(query core.Query) ([]core.SearchResult, error) {

--- a/google/search.go
+++ b/google/search.go
@@ -281,6 +281,23 @@ func (gogl *Google) Search(query core.Query) ([]core.SearchResult, error) {
 				srchRes.URL = href.String()
 			}
 
+			// Skip if URL is empty or we've already seen this URL
+			if srchRes.URL == "" {
+				continue
+			}
+
+			// Check for duplicates
+			isDuplicate := false
+			for _, existing := range searchResults {
+				if existing.URL == srchRes.URL {
+					isDuplicate = true
+					break
+				}
+			}
+			if isDuplicate {
+				continue
+			}
+
 			// Get description using multiple fallback strategies
 			desc := ""
 			if descTag, err := resEl.Element("div[data-sncf='1'] div"); err == nil {

--- a/google/search_raw.go
+++ b/google/search_raw.go
@@ -115,7 +115,7 @@ func googleResultParser(response *http.Response) ([]core.SearchResult, error) {
 	}
 
 	logrus.Tracef("Google search document size: %d", len(doc.Text()))
-	return results, err
+	return core.DeduplicateResults(results), err
 }
 
 func Search(query core.Query) ([]core.SearchResult, error) {

--- a/yandex/search.go
+++ b/yandex/search.go
@@ -169,7 +169,7 @@ func (yand *Yandex) Search(query core.Query) ([]core.SearchResult, error) {
 		time.Sleep(yand.pageSleep)
 	}
 
-	return allResults, nil
+	return core.DeduplicateResults(allResults), nil
 }
 
 func (yand *Yandex) SearchImage(query core.Query) ([]core.SearchResult, error) {
@@ -242,5 +242,5 @@ func (yand *Yandex) SearchImage(query core.Query) ([]core.SearchResult, error) {
 		return searchResults[i].Rank < searchResults[j].Rank
 	})
 
-	return searchResults, nil
+	return core.DeduplicateResults(searchResults), nil
 }

--- a/yandex/search_raw.go
+++ b/yandex/search_raw.go
@@ -1,8 +1,11 @@
 package yandex
 
 import (
+	"crypto/tls"
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/corpix/uarand"
@@ -10,8 +13,27 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func yandexRequest(searchURL string) (*http.Response, error) {
-	baseClient := &http.Client{}
+func yandexRequest(searchURL string, query core.Query) (*http.Response, error) {
+	// Create HTTP transport with proxy
+	transport := &http.Transport{}
+	if query.ProxyURL != "" {
+		proxyUrl, err := url.Parse(query.ProxyURL)
+		if err != nil {
+			return nil, err
+		}
+		transport.Proxy = http.ProxyURL(proxyUrl)
+	}
+
+	// Set insecure TLS
+	if query.Insecure {
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	}
+
+	baseClient := &http.Client{
+		Transport: transport,
+		Timeout:   time.Second * 10,
+	}
+
 	req, err := http.NewRequest("GET", searchURL, nil)
 	if err != nil {
 		return nil, err
@@ -26,7 +48,7 @@ func yandexRequest(searchURL string) (*http.Response, error) {
 }
 
 func yandexResultParser(response *http.Response) ([]core.SearchResult, error) {
-	doc, err := goquery.NewDocumentFromResponse(response)
+	doc, err := goquery.NewDocumentFromReader(response.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +99,7 @@ func Search(query core.Query) ([]core.SearchResult, error) {
 	}
 	logrus.Debugf("Yandex URL built: %s", googleURL)
 
-	res, err := yandexRequest(googleURL)
+	res, err := yandexRequest(googleURL, query)
 	if err != nil {
 		return nil, err
 	}

--- a/yandex/search_raw.go
+++ b/yandex/search_raw.go
@@ -89,7 +89,7 @@ func yandexResultParser(response *http.Response) ([]core.SearchResult, error) {
 	}
 
 	logrus.Tracef("Yandex search document size: %d", len(doc.Text()))
-	return results, err
+	return core.DeduplicateResults(results), err
 }
 
 func Search(query core.Query) ([]core.SearchResult, error) {


### PR DESCRIPTION
# Support http and socks5 proxy and fix failure due to updates of DOM on Google SERP

## Overview

This pull request introduces http and socks5 proxy support for both raw and browser mode. Besides, the code of extracting search results from scraped html is updated as Google updated DOM of search result pages. (`g` class is removed)

## Proxy

Both browser mode and raw mode support HTTP and SOCKS5 proxies with authentication:

```bash
# HTTP proxy with auth
openserp search google "query" --proxy http://user:pass@127.0.0.1:8080

# Serve with SOCKS5 proxy
openserp serve --proxy socks5://127.0.0.1:1080

# For HTTPS sites through HTTP proxy, use --insecure to ignore certificate errors
openserp search google "query" --proxy http://127.0.0.1:8080 --insecure
openserp search google "query" -x http://127.0.0.1:8080 -k
```

I have not tested http proxy with authentication in browser mode because I don't have any for now. I wrote that part based on [rod documentation](https://pkg.go.dev/github.com/go-rod/rod#example-package-Customize_browser_launch).

## Google SERP DOM updates

Before Jan 2025 (maybe Feb or Mar?), there was a `g` class for every search result (see [web archive of searching "DeepMind" on Google](https://web.archive.org/web/20240713051950/https://www.google.com/search?q=DeepMind)). That was how openserp extract the results. This does not work now. Implementation in this PR:

```go
...
	// Use data attributes instead of class names to find results
	// Both old and new DOM have data-hveid and data-ved attributes
	sel := doc.Find("div[data-hveid][data-ved]")

	for i := range sel.Nodes {
		item := sel.Eq(i)

		// Skip items without an h3 element (which indicates a search result)
		if item.Find("h3").Length() == 0 {
			continue
		}

		// Find URL - look for the anchor that contains the h3 title
		linkTag := item.Find("h3").Parent()
		if linkTag.Is("a") == false {
			linkTag = item.Find("h3").Closest("a")
		}

		link, exists := linkTag.Attr("href")
		if !exists || link == "" || link == "#" {
			continue
		}
		link = strings.Trim(link, " ")

		// Find title - this is inside the h3 element
		titleTag := item.Find("h3")
		title := titleTag.Text()

		// Find description - find div with text content after the heading
		// Using attribute selectors that match the description container
		descTag := item.Find("div[data-sncf='1']").Find("div").First()
		if descTag.Length() == 0 {
			// Try another selector approach if the first one fails
			descTag = item.Find("div.VwiC3b")
			if descTag.Length() == 0 {
				// As a last resort, look for any div after the title that might contain description
				titleParent := titleTag.Parent()
				if titleParent.Is("a") {
					titleParent = titleParent.Parent().Parent()
				}
				descTag = titleParent.NextAll().First().Find("div").First()
			}
		}
...
```

## Remove duplicates

The first two results of Google (both raw and browser) are identical, maybe due to the new extracting logic mentioned above. Anyway it is fixed by removing duplicated (same url) results everywhere.

## Fix search crash mentioned in #7

Fix search crash ((slice bounds out of range [4:1])) mentioned in #7.
The fix: https://github.com/karust/openserp/issues/7#issuecomment-2254143288
This no longer matters, as the extraction logic has completely changed as mentioned above.

## Possible issues

1. I have not tested http proxy with authentication in browser mode because I don't have any for now. I wrote that part based on [rod documentation](https://pkg.go.dev/github.com/go-rod/rod#example-package-Customize_browser_launch).
2. Baidu in raw mode may have issues?

I may support [Bing](https://www.bing.com/) and [Brave](https://search.brave.com/) in the future and PR.